### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 ![](https://img.shields.io/github/license/Joooook/12306-mcp.svg?style=flat-square&color=000000)
 </div>
 
-
-## <div align="center">👋Introduction</div>
-This is a 12306 ticket search server based on the Model Context Protocol (MCP). The server provides a simple API interface that allows users to search for 12306 tickets.
+A 12306 ticket search server based on the Model Context Protocol (MCP). The server provides a simple API interface that allows users to search for 12306 tickets.
 
 基于 Model Context Protocol (MCP) 的12306购票搜索服务器。提供了简单的API接口，允许大模型利用接口搜索12306购票信息。
+
+<a href="https://glama.ai/mcp/servers/@Joooook/12306-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Joooook/12306-mcp/badge" alt="12306-mcp MCP server" />
+</a>
 
 ## <div align="center">🚩Features</div>
 


### PR DESCRIPTION
This PR adds a badge for the [12306-mcp](https://glama.ai/mcp/servers/@Joooook/12306-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Joooook/12306-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Joooook/12306-mcp/badge" alt="12306-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.